### PR TITLE
Inherit checkbashisms path from $PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Bashisms are constructs often found in shell scripts that are only guaranteed to
 
 ## Prerequisites
 
-You'll need a copy of `checkbashisms` installed; this package assumes it's at `/usr/local/bin/checkbashisms` but you can change that in Atom's settings.
+You'll need a copy of `checkbashisms` installed on your `$PATH`. You can also
+manually set the path in Atom's settings.
 
 On Debian-style Linuxes:
 

--- a/lib/checkbashisms.coffee
+++ b/lib/checkbashisms.coffee
@@ -5,7 +5,7 @@ module.exports = Checkbashisms =
     executablePath:
       title: 'checkbashisms script path'
       type: 'string'
-      default: '/usr/local/bin/checkbashisms'
+      default: 'checkbashisms'
 
   activate: ->
     console.log 'Activating checkbashisms'


### PR DESCRIPTION
I think it makes more sense just to look for checkbashisms in whatever the user
has set in $PATH. That way you also cover the default Debian install path
(which is not in /usr/local).

This shouldn't break any existing setups, unless `/usr/local/bin` is not in
their $PATH. I'd imagine that that's extremely unusual though, since otherwise
you wouldn't be able to easily access tools linked by Homebrew.
